### PR TITLE
Fix spline examples

### DIFF
--- a/src/roadrunner_10/BuilderReference.java
+++ b/src/roadrunner_10/BuilderReference.java
@@ -76,14 +76,14 @@
 // Robot moves to the specified coordinates while linearly interpolating between the start heading and a specified end heading
 // In other words, it constantly turns to a certain heading (once more, in radians) while moving to the specified coordinates.
 
-.strafeToLinearHeading(new Vector2d(36, 36), Math.toRadians(90))
+.strafeToLinearHeading(new Vector2d(48, -48), Math.toRadians(180))
 
 
 
 // Robot moves to the specified coordinates while splinely interpolating between the start heading and a specified end heading
 // In other words, it constantly turns to a certain heading (once more, in radians) while moving to the specified coordinates.
 
-.strafeToSplineHeading(new Vector2d(36, 36), Math.toRadians(90))
+.strafeToSplineHeading(new Vector2d(48, -48), Math.toRadians(180))
 
 
 


### PR DESCRIPTION
Great examples in the cookbook! Thanks for adding those.

The videos for strafeToLinearHeading and strafeToSplineHeading show a target position of 48, -48 with a heading of 180 degrees which is consistent with the video and code for strafeTo and strafeToConstantHeading, but the code for strafeToLinearHeading and strafeToSplineHeading show 36, -36 and 90 degrees. Fix the code to make it consistent.

Correct:
![image](https://github.com/user-attachments/assets/c60a0507-605d-4370-b337-ca2d437103ff)

Incorrect:
![image](https://github.com/user-attachments/assets/1f7d46a8-0c66-44c7-ac08-5533b55a256c)
![image](https://github.com/user-attachments/assets/8fb7bb45-f281-41cd-9d9a-9c7951c3fe53)
